### PR TITLE
Remove database setup from Docker script 

### DIFF
--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -46,4 +46,4 @@ RUN cd /usr/src/app/memberportal/ \
 
 # Expose the port and run the app
 EXPOSE 8000
-CMD ["sh", "/usr/src/app/docker/container_start.sh"]
+CMD ["sh", "/usr/src/app/docker/container_start_no_setup.sh"]

--- a/docker/container_start_no_setup.sh
+++ b/docker/container_start_no_setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Start nginx
+nginx
+
+# Navigate to the app and start gunicorn
+cd memberportal
+
+# We should migrate on startup in case there's been any db changes
+python3 manage.py migrate
+
+if [ ! -f /usr/src/data/setupcomplete ]; then
+    echo "INFO: Detected a first time run. Populating the database with defaults."
+    python3 manage.py loaddata initial
+    touch /usr/src/data/setupcomplete
+fi
+
+exec gunicorn membermatters.wsgi:application --bind unix:/tmp/gunicorn.sock --access-logfile '/usr/src/logs/access.log' --error-logfile '/usr/src/logs/error.log' --workers 6

--- a/docker/container_start_no_setup.sh
+++ b/docker/container_start_no_setup.sh
@@ -9,10 +9,4 @@ cd memberportal
 # We should migrate on startup in case there's been any db changes
 python3 manage.py migrate
 
-if [ ! -f /usr/src/data/setupcomplete ]; then
-    echo "INFO: Detected a first time run. Populating the database with defaults."
-    python3 manage.py loaddata initial
-    touch /usr/src/data/setupcomplete
-fi
-
 exec gunicorn membermatters.wsgi:application --bind unix:/tmp/gunicorn.sock --access-logfile '/usr/src/logs/access.log' --error-logfile '/usr/src/logs/error.log' --workers 6

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -75,12 +75,28 @@ copilot pipeline update
 
 # Manual deploy app
 
+From the command line, pushing any local changes straight to production:
 ```bash
 copilot svc deploy
 ```
+
+From the AWS console, pulling in the latest `main` branch from github and deploying it:
+
+https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/pipeline-mm-MemberMatters/view?region=ap-southeast-2
+
+then click 'Release change' at the top.
 
 # Connect to running instance
 
 ```bash
 copilot svc exec --name frontend --env prod -c /bin/bash
 ```
+
+# Automatic Deployments
+
+When a merge to main happens, AWS kicks off an automatic build and deployment of the latest code. 
+
+Follow along with progress here: https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/pipeline-mm-MemberMatters/view?region=ap-southeast-2 
+
+If something doesn't work right, CloudFormation will time out after 30 or so minutes. To make that process quicker you can scale down the number of instances (ECS -> Clusters -> open Cluster -> open Service -> click Update -> next,next,change Desired Count to 0)
+


### PR DESCRIPTION
We don't have a persistent data directory in AWS, so the initial setup script was blowing away the RDS database each time it ran. 

Relevant code:

https://github.com/gctechspace/MemberMatters/blob/main/docker/container_start.sh#L12-L16

## Changes

- Remove the initial setup from the docker start script and use that in AWS Docker file 
- Add some links and info about AWS deployments
